### PR TITLE
feat: adiciona filtro por equipamento em horários ocupados e nova rot…

### DIFF
--- a/src/main/java/br/uece/alunos/sisreserva/v1/controller/EquipamentoController.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/controller/EquipamentoController.java
@@ -4,9 +4,11 @@ import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoAtualizarDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoRetornoDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EstatisticasGeralEquipamentoDTO;
+import br.uece.alunos.sisreserva.v1.dto.solicitacaoReserva.HorariosOcupadosPorMesDTO;
 import br.uece.alunos.sisreserva.v1.dto.utils.ApiResponseDTO;
 import br.uece.alunos.sisreserva.v1.service.EquipamentoService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
@@ -107,6 +109,33 @@ public class EquipamentoController {
             @RequestBody EquipamentoAtualizarDTO data) {
         var atualizado = service.atualizar(id, data);
         return ResponseEntity.ok(ApiResponseDTO.success(atualizado));
+    }
+
+    /**
+     * Retorna os horários ocupados de um equipamento em um mês específico.
+     *
+     * Inclui tanto reservas simples aprovadas (agrupadas por dia em
+     * {@code diasComHorariosOcupados}) quanto séries recorrentes aprovadas (em
+     * {@code seriesRecorrentes}), com suas ocorrências efetivas no mês após aplicar
+     * eventuais exceções de recorrência.
+     *
+     * @param id  ID do equipamento
+     * @param mes mês (1-12); usa o mês atual quando omitido
+     * @param ano ano; usa o ano atual quando omitido
+     * @return horários ocupados do equipamento no mês
+     */
+    @GetMapping("/{id}/horarios-ocupados")
+    @Operation(summary = "Obter horários ocupados do equipamento",
+               description = "Retorna reservas aprovadas do equipamento no mês, agrupadas por dia " +
+                             "(reservas simples) e como séries recorrentes separadamente.")
+    public ResponseEntity<ApiResponseDTO<HorariosOcupadosPorMesDTO>> obterHorariosOcupados(
+            @PathVariable String id,
+            @Parameter(description = "Mês (1-12); usa o mês atual quando omitido")
+            @RequestParam(required = false) Integer mes,
+            @Parameter(description = "Ano; usa o ano atual quando omitido")
+            @RequestParam(required = false) Integer ano) {
+        var horariosOcupados = service.obterHorariosOcupadosPorEquipamento(id, mes, ano);
+        return ResponseEntity.ok(ApiResponseDTO.success(horariosOcupados));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/br/uece/alunos/sisreserva/v1/controller/SolicitacaoReservaController.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/controller/SolicitacaoReservaController.java
@@ -79,11 +79,18 @@ public class SolicitacaoReservaController {
     }
 
     @GetMapping("/horarios-ocupados")
+    @Operation(summary = "Obter horários ocupados por mês",
+               description = "Retorna reservas aprovadas do mês agrupadas por dia e séries recorrentes. " +
+                             "Filtrar por espaço via 'espacoId' ou por equipamento via 'equipamentoId'. " +
+                             "Apenas um filtro é considerado por chamada; 'equipamentoId' tem precedência.")
     public ResponseEntity<ApiResponseDTO<HorariosOcupadosPorMesDTO>> obterHorariosOcupados(
             @RequestParam(required = false) Integer mes,
             @RequestParam(required = false) Integer ano,
-            @RequestParam(required = false) String espacoId) {
-        var horariosOcupados = solicitacaoReservaService.obterHorariosOcupadosPorMes(mes, ano, espacoId);
+            @RequestParam(required = false) String espacoId,
+            @Parameter(description = "Filtra horários ocupados de um equipamento específico; tem precedência sobre espacoId")
+            @RequestParam(required = false) String equipamentoId) {
+        var horariosOcupados = solicitacaoReservaService.obterHorariosOcupadosPorMes(
+                mes, ano, espacoId, equipamentoId);
         return ResponseEntity.ok(ApiResponseDTO.success(horariosOcupados));
     }
 

--- a/src/main/java/br/uece/alunos/sisreserva/v1/domain/equipamento/useCase/ObterHorariosOcupadosEquipamento.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/domain/equipamento/useCase/ObterHorariosOcupadosEquipamento.java
@@ -1,6 +1,6 @@
-package br.uece.alunos.sisreserva.v1.domain.espaco.useCase;
+package br.uece.alunos.sisreserva.v1.domain.equipamento.useCase;
 
-import br.uece.alunos.sisreserva.v1.domain.espaco.validation.EspacoValidator;
+import br.uece.alunos.sisreserva.v1.domain.equipamento.validation.EquipamentoValidator;
 import br.uece.alunos.sisreserva.v1.domain.solicitacaoReserva.ExcecaoRecorrencia;
 import br.uece.alunos.sisreserva.v1.domain.solicitacaoReserva.ExcecaoRecorrenciaRepository;
 import br.uece.alunos.sisreserva.v1.domain.solicitacaoReserva.SolicitacaoReserva;
@@ -23,8 +23,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Caso de uso para obter os horários ocupados de um equipamento em um mês específico.
+ *
+ * Combina dois tipos de fontes:
+ * 
+ *   - Reservas simples (registros com {@code isSerie = false}) aprovadas no mês.
+ *   - Séries recorrentes aprovadas (registros com {@code isSerie = true}) cujas ocorrências
+ *       calculadas caem no mês – aplicando exceções quando existirem.
+ * 
+ *
+ * Segue o mesmo padrão de {@code ObterHorariosOcupadosEspaco}, porém filtrando pelo
+ * campo {@code equipamento.id} da solicitação de reserva.
+ *
+ * @author Sistema de Reservas UECE
+ * @see br.uece.alunos.sisreserva.v1.domain.espaco.useCase.ObterHorariosOcupadosEspaco
+ */
 @Component
-public class ObterHorariosOcupadosEspaco {
+public class ObterHorariosOcupadosEquipamento {
 
     @Autowired
     private SolicitacaoReservaRepository solicitacaoReservaRepository;
@@ -33,11 +49,28 @@ public class ObterHorariosOcupadosEspaco {
     private ExcecaoRecorrenciaRepository excecaoRepository;
 
     @Autowired
-    private EspacoValidator espacoValidator;
+    private EquipamentoValidator equipamentoValidator;
 
-    public HorariosOcupadosPorMesDTO obterHorariosOcupadosPorEspaco(String espacoId, Integer mes, Integer ano) {
-        espacoValidator.validarEspacoId(espacoId);
+    /**
+     * Retorna os horários ocupados de um equipamento em um mês específico.
+     *
+     * <p>Reservas simples são agrupadas por dia em {@code diasComHorariosOcupados}.
+     * Séries recorrentes são listadas separadamente em {@code seriesRecorrentes}, cada uma
+     * com suas ocorrências efetivas no mês (após aplicação de eventuais exceções).</p>
+     *
+     * @param equipamentoId ID do equipamento; deve existir no banco
+     * @param mes           mês (1-12); se {@code null} e {@code ano} também for nulo, usa o mês atual;
+     *                      se apenas {@code mes} for informado, combina com o ano atual
+     * @param ano           ano; se {@code null} e {@code mes} também for nulo, usa o ano atual;
+     *                      se apenas {@code ano} for informado, combina com o mês atual
+     * @return horários ocupados agrupados por dia e séries recorrentes
+     */
+    public HorariosOcupadosPorMesDTO obterHorariosOcupadosPorEquipamento(
+            String equipamentoId, Integer mes, Integer ano) {
 
+        equipamentoValidator.validarEquipamentoId(equipamentoId);
+
+        // Determinar o mês/ano alvo, aceitando informação parcial
         YearMonth yearMonth;
         if (mes != null && ano != null) {
             yearMonth = YearMonth.of(ano, mes);
@@ -50,12 +83,13 @@ public class ObterHorariosOcupadosEspaco {
         }
 
         LocalDateTime inicioMes = yearMonth.atDay(1).atStartOfDay();
-        LocalDateTime fimMes = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+        LocalDateTime fimMes    = yearMonth.atEndOfMonth().atTime(23, 59, 59);
 
-        // 1) Reservas simples/legadas aprovadas no período (isSerie = false)
+        // ─── 1) Reservas simples aprovadas no período (isSerie = false) ───────────────
         List<SolicitacaoReserva> simples = solicitacaoReservaRepository
-                .findReservasAprovadasPorPeriodoEEspaco(inicioMes, fimMes, espacoId);
+                .findReservasAprovadasSimplesPorPeriodoEEquipamento(inicioMes, fimMes, equipamentoId);
 
+        // Agrupar reservas simples por dia
         Map<LocalDate, List<HorarioOcupadoDTO>> porDia = simples.stream()
                 .map(this::converterParaHorarioOcupadoDTO)
                 .collect(Collectors.groupingBy(h -> h.dataInicio().toLocalDate()));
@@ -65,13 +99,14 @@ public class ObterHorariosOcupadosEspaco {
                 .sorted(Comparator.comparing(HorariosOcupadosPorDiaDTO::data))
                 .collect(Collectors.toList());
 
-        // 2) Séries recorrentes aprovadas com ocorrências no mês (isSerie = true)
+        // ─── 2) Séries recorrentes aprovadas com ocorrências no mês (isSerie = true) ──
         List<SolicitacaoReserva> series = solicitacaoReservaRepository
-                .findSeriesAprovadasDoEspacoNoPeriodo(espacoId, inicioMes, fimMes);
+                .findSeriesAprovadasDoEquipamentoNoPeriodo(equipamentoId, inicioMes, fimMes);
 
         List<SerieHorariosOcupadosDTO> seriesRecorrentes = new ArrayList<>();
 
         if (!series.isEmpty()) {
+            // Carregar exceções de todas as séries em lote (evitar N+1)
             List<String> serieIds = series.stream()
                     .map(SolicitacaoReserva::getId)
                     .collect(Collectors.toList());
@@ -95,6 +130,8 @@ public class ObterHorariosOcupadosEspaco {
                         serie.getDataInicio(), serie.getDataFimRecorrencia(), serie.getTipoRecorrencia())) {
 
                     ExcecaoRecorrencia excecao = excecoesDaSerie.get(dataOcorrencia.toLocalDate());
+
+                    // Ocorrências canceladas ou recusadas não ocupam horário
                     StatusSolicitacao statusEfetivo = excecao != null ? excecao.getStatus() : serie.getStatus();
                     if (statusEfetivo != StatusSolicitacao.APROVADO) continue;
 
@@ -103,14 +140,15 @@ public class ObterHorariosOcupadosEspaco {
                     LocalDateTime fimEfetivo = excecao != null && excecao.getDataFimNova() != null
                             ? excecao.getDataFimNova() : inicioEfetivo.plusMinutes(duracaoMinutos);
 
+                    // Verificar se esta ocorrência está dentro do mês (usando horários efetivos)
                     boolean dentroDoMes = !inicioEfetivo.isAfter(fimMes) && !fimEfetivo.isBefore(inicioMes);
                     if (!dentroDoMes) continue;
 
                     ocorrenciasNoMes.add(new HorarioOcupadoDTO(
-                            serie.getEspaco() != null ? serie.getEspaco().getId() : null,
-                            serie.getEspaco() != null ? serie.getEspaco().getNome() : null,
                             null,
                             null,
+                            serie.getEquipamento() != null ? serie.getEquipamento().getId() : null,
+                            serie.getEquipamento() != null ? serie.getEquipamento().getTombamento() : null,
                             inicioEfetivo,
                             fimEfetivo,
                             serie.getUsuarioSolicitante().getNome(),
@@ -121,10 +159,10 @@ public class ObterHorariosOcupadosEspaco {
                 if (!ocorrenciasNoMes.isEmpty()) {
                     seriesRecorrentes.add(new SerieHorariosOcupadosDTO(
                             serie.getId(),
-                            serie.getEspaco() != null ? serie.getEspaco().getId() : null,
-                            serie.getEspaco() != null ? serie.getEspaco().getNome() : null,
                             null,
                             null,
+                            serie.getEquipamento() != null ? serie.getEquipamento().getId() : null,
+                            serie.getEquipamento() != null ? serie.getEquipamento().getTombamento() : null,
                             serie.getUsuarioSolicitante().getNome(),
                             serie.getProjeto() != null ? serie.getProjeto().getNome() : null,
                             ocorrenciasNoMes
@@ -141,12 +179,15 @@ public class ObterHorariosOcupadosEspaco {
         );
     }
 
+    /**
+     * Converte uma reserva simples de equipamento em DTO de horário ocupado.
+     */
     private HorarioOcupadoDTO converterParaHorarioOcupadoDTO(SolicitacaoReserva reserva) {
         return new HorarioOcupadoDTO(
-                reserva.getEspaco().getId(),
-                reserva.getEspaco().getNome(),
                 null,
                 null,
+                reserva.getEquipamento() != null ? reserva.getEquipamento().getId() : null,
+                reserva.getEquipamento() != null ? reserva.getEquipamento().getTombamento() : null,
                 reserva.getDataInicio(),
                 reserva.getDataFim(),
                 reserva.getUsuarioSolicitante().getNome(),

--- a/src/main/java/br/uece/alunos/sisreserva/v1/domain/solicitacaoReserva/SolicitacaoReservaRepository.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/domain/solicitacaoReserva/SolicitacaoReservaRepository.java
@@ -769,6 +769,59 @@ public interface SolicitacaoReservaRepository extends JpaRepository<SolicitacaoR
     );
 
     /**
+     * Busca reservas simples (não-série) aprovadas de um equipamento em um período específico,
+     * com eager load dos relacionamentos necessários para montar o DTO de horários ocupados.
+     *
+     * @param dataInicio    início do período (inclusive)
+     * @param dataFim       fim do período (exclusive)
+     * @param equipamentoId ID do equipamento
+     * @return lista de reservas simples aprovadas, ordenadas por data de início
+     */
+    @Query("""
+        SELECT s FROM SolicitacaoReserva s
+        JOIN FETCH s.usuarioSolicitante
+        JOIN FETCH s.equipamento
+        LEFT JOIN FETCH s.projeto
+        WHERE s.equipamento.id = :equipamentoId
+          AND s.status = br.uece.alunos.sisreserva.v1.domain.solicitacaoReserva.StatusSolicitacao.APROVADO
+          AND s.isSerie = false
+          AND s.dataInicio >= :dataInicio
+          AND s.dataInicio < :dataFim
+        ORDER BY s.dataInicio ASC
+    """)
+    List<SolicitacaoReserva> findReservasAprovadasSimplesPorPeriodoEEquipamento(
+        @Param("dataInicio") LocalDateTime dataInicio,
+        @Param("dataFim") LocalDateTime dataFim,
+        @Param("equipamentoId") String equipamentoId
+    );
+
+    /**
+     * Busca séries recorrentes aprovadas de um equipamento com ocorrências no intervalo dado.
+     * Usado para obter horários ocupados do equipamento.
+     *
+     * @param equipamentoId ID do equipamento
+     * @param periodoInicio início do período
+     * @param periodoFim    fim do período
+     * @return séries aprovadas do equipamento com sobreposição de período
+     */
+    @Query("""
+        SELECT sr FROM SolicitacaoReserva sr
+        JOIN FETCH sr.usuarioSolicitante
+        JOIN FETCH sr.equipamento
+        LEFT JOIN FETCH sr.projeto
+        WHERE sr.equipamento.id = :equipamentoId
+          AND sr.isSerie = true
+          AND sr.status = br.uece.alunos.sisreserva.v1.domain.solicitacaoReserva.StatusSolicitacao.APROVADO
+          AND sr.dataInicio <= :periodoFim
+          AND sr.dataFimRecorrencia >= :periodoInicio
+    """)
+    List<SolicitacaoReserva> findSeriesAprovadasDoEquipamentoNoPeriodo(
+        @Param("equipamentoId") String equipamentoId,
+        @Param("periodoInicio") LocalDateTime periodoInicio,
+        @Param("periodoFim") LocalDateTime periodoFim
+    );
+
+    /**
      * Busca séries recorrentes aprovadas de um espaço com ocorrências no intervalo dado.
      * Usado para obter horários ocupados.
      *

--- a/src/main/java/br/uece/alunos/sisreserva/v1/domain/solicitacaoReserva/useCase/ObterHorariosOcupados.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/domain/solicitacaoReserva/useCase/ObterHorariosOcupados.java
@@ -20,16 +20,21 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Caso de uso para obter horários ocupados em um mês para um espaço.
+ * Caso de uso para obter horários ocupados em um mês, com suporte a filtro por espaço
+ * ou equipamento.
  *
  * Combina dois tipos de fontes:
  * 
- *   - Reservas simples e legadas (registros com {@code isSerie = false}) aprovadas no mês.
+ *   - Reservas simples (registros com {@code isSerie = false}) aprovadas no mês.
  *   - Séries recorrentes aprovadas (registros com {@code isSerie = true}) cujas ocorrências
  *       calculadas caem no mês – aplicando exceções quando existirem.
+ * 
+ *
+ * Apenas um dos filtros {@code espacoId} ou {@code equipamentoId} deve ser informado
+ * por chamada. Se ambos forem nulos, o resultado abrange todos os recursos.
  *
  * @author Sistema de Reservas UECE
- * @version 2.0
+ * @version 3.0
  */
 @Component
 public class ObterHorariosOcupados {
@@ -41,14 +46,22 @@ public class ObterHorariosOcupados {
     private ExcecaoRecorrenciaRepository excecaoRepository;
 
     /**
-     * Obtém os horários ocupados de um mês específico, opcionalmente filtrados por espaço.
+     * Obtém os horários ocupados de um mês específico, com filtro opcional por espaço
+     * ou equipamento.
      *
-     * @param mes      mês (1-12); se {@code null}, usa o mês atual
-     * @param ano      ano; se {@code null}, usa o ano atual
-     * @param espacoId ID do espaço para filtrar; se {@code null}, retorna todos os espaços
-     * @return horários ocupados agrupados por dia
+     * Ao informar {@code equipamentoId}, apenas reservas desse equipamento são retornadas.
+     * Ao informar {@code espacoId}, apenas reservas desse espaço são retornadas.
+     * Se nenhum filtro for informado, todas as reservas aprovadas do mês são retornadas.
+     *
+     * @param mes           mês (1-12); se {@code null}, usa o mês atual
+     * @param ano           ano; se {@code null}, usa o ano atual
+     * @param espacoId      ID do espaço para filtrar; ignorado quando {@code equipamentoId} é informado
+     * @param equipamentoId ID do equipamento para filtrar; tem precedência sobre {@code espacoId}
+     * @return horários ocupados agrupados por dia e séries recorrentes
      */
-    public HorariosOcupadosPorMesDTO obterHorariosOcupadosPorMes(Integer mes, Integer ano, String espacoId) {
+    public HorariosOcupadosPorMesDTO obterHorariosOcupadosPorMes(
+            Integer mes, Integer ano, String espacoId, String equipamentoId) {
+
         YearMonth yearMonth = (mes != null && ano != null)
                 ? YearMonth.of(ano, mes)
                 : YearMonth.now();
@@ -56,12 +69,19 @@ public class ObterHorariosOcupados {
         LocalDateTime inicioMes = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime fimMes    = yearMonth.atEndOfMonth().atTime(23, 59, 59);
 
+        boolean filtrarEquipamento = equipamentoId != null && !equipamentoId.isBlank();
+        boolean filtrarEspaco      = !filtrarEquipamento && espacoId != null && !espacoId.isBlank();
+
         List<HorarioOcupadoDTO> horariosOcupados = new ArrayList<>();
 
-        // 1) Reservas simples/legadas aprovadas no período (isSerie = false)
+        // ─── 1) Reservas simples aprovadas no período (isSerie = false) ───────────────
         List<SolicitacaoReserva> simples;
-        if (espacoId != null && !espacoId.isBlank()) {
-            simples = repository.findReservasAprovadasPorPeriodoEEspaco(inicioMes, fimMes, espacoId.trim());
+        if (filtrarEquipamento) {
+            simples = repository.findReservasAprovadasSimplesPorPeriodoEEquipamento(
+                    inicioMes, fimMes, equipamentoId.trim());
+        } else if (filtrarEspaco) {
+            simples = repository.findReservasAprovadasPorPeriodoEEspaco(
+                    inicioMes, fimMes, espacoId.trim());
         } else {
             simples = repository.findReservasAprovadasPorPeriodo(inicioMes, fimMes);
         }
@@ -69,17 +89,22 @@ public class ObterHorariosOcupados {
                 .map(this::converterParaHorarioOcupadoDTO)
                 .forEach(horariosOcupados::add);
 
-        // 2) Séries recorrentes aprovadas com ocorrências no mês (isSerie = true)
+        // ─── 2) Séries recorrentes aprovadas com ocorrências no mês (isSerie = true) ──
         List<SolicitacaoReserva> series;
-        if (espacoId != null && !espacoId.isBlank()) {
-            series = repository.findSeriesAprovadasDoEspacoNoPeriodo(espacoId.trim(), inicioMes, fimMes);
+        if (filtrarEquipamento) {
+            series = repository.findSeriesAprovadasDoEquipamentoNoPeriodo(
+                    equipamentoId.trim(), inicioMes, fimMes);
+        } else if (filtrarEspaco) {
+            series = repository.findSeriesAprovadasDoEspacoNoPeriodo(
+                    espacoId.trim(), inicioMes, fimMes);
         } else {
             series = repository.findSeriesAprovadasNoPeriodo(inicioMes, fimMes);
         }
 
         if (!series.isEmpty()) {
             // Carregar exceções de todas as séries em lote (evitar N+1)
-            List<String> serieIds = series.stream().map(SolicitacaoReserva::getId).collect(Collectors.toList());
+            List<String> serieIds = series.stream()
+                    .map(SolicitacaoReserva::getId).collect(Collectors.toList());
             List<ExcecaoRecorrencia> todasExcecoes = excecaoRepository.findBySerieIds(serieIds);
             Map<String, Map<LocalDate, ExcecaoRecorrencia>> excecoesPorSerie = todasExcecoes.stream()
                     .collect(Collectors.groupingBy(
@@ -93,7 +118,6 @@ public class ObterHorariosOcupados {
                 Map<LocalDate, ExcecaoRecorrencia> excecoesDaSerie =
                         excecoesPorSerie.getOrDefault(serie.getId(), Map.of());
 
-                // Calcular todas as ocorrências e filtrar as que caem no mês
                 List<LocalDateTime> ocorrencias = RecorrenciaProcessor.gerarDatasDasOcorrencias(
                         serie.getDataInicio(),
                         serie.getDataFimRecorrencia(),
@@ -101,7 +125,6 @@ public class ObterHorariosOcupados {
                 );
 
                 for (LocalDateTime dataOcorrencia : ocorrencias) {
-                    // Aplicar exceção (se existir) para obter status e horários efetivos
                     ExcecaoRecorrencia excecao = excecoesDaSerie.get(dataOcorrencia.toLocalDate());
 
                     // Ocorrências canceladas ou recusadas não ocupam horário
@@ -121,6 +144,8 @@ public class ObterHorariosOcupados {
                     horariosOcupados.add(new HorarioOcupadoDTO(
                             serie.getEspaco() != null ? serie.getEspaco().getId() : null,
                             serie.getEspaco() != null ? serie.getEspaco().getNome() : null,
+                            serie.getEquipamento() != null ? serie.getEquipamento().getId() : null,
+                            serie.getEquipamento() != null ? serie.getEquipamento().getTombamento() : null,
                             inicioEfetivo,
                             fimEfetivo,
                             serie.getUsuarioSolicitante().getNome(),
@@ -149,11 +174,14 @@ public class ObterHorariosOcupados {
 
     /**
      * Converte uma reserva simples/legada em DTO de horário ocupado.
+     * Popula os campos de espaço ou equipamento conforme o tipo da reserva.
      */
     private HorarioOcupadoDTO converterParaHorarioOcupadoDTO(SolicitacaoReserva reserva) {
         return new HorarioOcupadoDTO(
-                reserva.getEspaco().getId(),
-                reserva.getEspaco().getNome(),
+                reserva.getEspaco() != null ? reserva.getEspaco().getId() : null,
+                reserva.getEspaco() != null ? reserva.getEspaco().getNome() : null,
+                reserva.getEquipamento() != null ? reserva.getEquipamento().getId() : null,
+                reserva.getEquipamento() != null ? reserva.getEquipamento().getTombamento() : null,
                 reserva.getDataInicio(),
                 reserva.getDataFim(),
                 reserva.getUsuarioSolicitante().getNome(),

--- a/src/main/java/br/uece/alunos/sisreserva/v1/dto/solicitacaoReserva/HorarioOcupadoDTO.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/dto/solicitacaoReserva/HorarioOcupadoDTO.java
@@ -2,9 +2,27 @@ package br.uece.alunos.sisreserva.v1.dto.solicitacaoReserva;
 
 import java.time.LocalDateTime;
 
+/**
+ * DTO que representa um horário ocupado por uma reserva aprovada.
+ *
+ * Os campos {@code espacoId}/{@code espacoNome} estão preenchidos quando a reserva é
+ * de um espaço; {@code equipamentoId}/{@code equipamentoNome} estão preenchidos quando
+ * a reserva é de um equipamento. Apenas um par é populado por vez.
+ *
+ * @param espacoId           ID do espaço reservado, ou {@code null} para reservas de equipamento
+ * @param espacoNome         nome do espaço reservado, ou {@code null} para reservas de equipamento
+ * @param equipamentoId      ID do equipamento reservado, ou {@code null} para reservas de espaço
+ * @param equipamentoNome    nome/tombamento do equipamento reservado, ou {@code null} para reservas de espaço
+ * @param dataInicio         data e hora de início da ocupação
+ * @param dataFim            data e hora de fim da ocupação
+ * @param usuarioSolicitante nome do usuário que realizou a reserva
+ * @param projetoNome        nome do projeto associado, ou {@code null} se não houver
+ */
 public record HorarioOcupadoDTO(
     String espacoId,
     String espacoNome,
+    String equipamentoId,
+    String equipamentoNome,
     LocalDateTime dataInicio,
     LocalDateTime dataFim,
     String usuarioSolicitante,

--- a/src/main/java/br/uece/alunos/sisreserva/v1/dto/solicitacaoReserva/SerieHorariosOcupadosDTO.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/dto/solicitacaoReserva/SerieHorariosOcupadosDTO.java
@@ -4,11 +4,17 @@ import java.util.List;
 
 /**
  * DTO que representa uma série recorrente e suas ocorrências aprovadas em um determinado mês,
- * retornado na listagem de horários ocupados de um espaço.
+ * retornado na listagem de horários ocupados de um espaço ou equipamento.
+ *
+ * Os campos {@code espacoId}/{@code espacoNome} estão preenchidos quando a série é de um
+ * espaço; {@code equipamentoId}/{@code equipamentoNome} estão preenchidos quando a série é de
+ * um equipamento. Apenas um par é populado por vez.
  *
  * @param serieId            ID da série ({@code SolicitacaoReserva.id} com {@code isSerie = true})
- * @param espacoId           ID do espaço reservado
- * @param espacoNome         nome do espaço reservado
+ * @param espacoId           ID do espaço reservado, ou {@code null} para séries de equipamento
+ * @param espacoNome         nome do espaço reservado, ou {@code null} para séries de equipamento
+ * @param equipamentoId      ID do equipamento reservado, ou {@code null} para séries de espaço
+ * @param equipamentoNome    nome/tombamento do equipamento reservado, ou {@code null} para séries de espaço
  * @param usuarioSolicitante nome do usuário que criou a série
  * @param projetoNome        nome do projeto associado, ou {@code null} se não houver
  * @param ocorrenciasNoMes   lista de ocorrências aprovadas da série que caem no mês filtrado
@@ -17,6 +23,8 @@ public record SerieHorariosOcupadosDTO(
     String serieId,
     String espacoId,
     String espacoNome,
+    String equipamentoId,
+    String equipamentoNome,
     String usuarioSolicitante,
     String projetoNome,
     List<HorarioOcupadoDTO> ocorrenciasNoMes

--- a/src/main/java/br/uece/alunos/sisreserva/v1/service/EquipamentoService.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/service/EquipamentoService.java
@@ -4,6 +4,7 @@ import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoAtualizarDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoRetornoDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EstatisticasGeralEquipamentoDTO;
+import br.uece.alunos.sisreserva.v1.dto.solicitacaoReserva.HorariosOcupadosPorMesDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -46,6 +47,21 @@ public interface EquipamentoService {
      */
     byte[] gerarPDFEstatisticas(Integer mesInicial, Integer anoInicial, Integer mesFinal, Integer anoFinal, List<String> equipamentoIds, String tipoEquipamentoId, Boolean multiusuario, String espacoId) throws java.io.IOException;
     
+    /**
+     * Obtém os horários ocupados de um equipamento em um mês específico.
+     *
+     * Retorna reservas simples aprovadas agrupadas por dia ({@code diasComHorariosOcupados})
+     * e séries recorrentes aprovadas com suas ocorrências efetivas no mês
+     * ({@code seriesRecorrentes}), considerando eventuais exceções de recorrência.
+     *
+     * @param equipamentoId ID do equipamento; deve existir no banco
+     * @param mes           mês (1-12); usa o mês atual quando núlo
+     * @param ano           ano; usa o ano atual quando nulo
+     * @return horários ocupados agrupados por dia e séries recorrentes
+     */
+    HorariosOcupadosPorMesDTO obterHorariosOcupadosPorEquipamento(
+            String equipamentoId, Integer mes, Integer ano);
+
     /**
      * Obtém equipamentos reserváveis com filtros e paginação.
      * Retorna apenas equipamentos com o campo 'reservavel' definido como true.

--- a/src/main/java/br/uece/alunos/sisreserva/v1/service/SolicitacaoReservaService.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/service/SolicitacaoReservaService.java
@@ -74,14 +74,20 @@ public interface SolicitacaoReservaService {
     SolicitacaoReservaRetornoDTO atualizarStatus(String id, AtualizarStatusSolicitacaoDTO data);
 
     /**
-     * Obtém os horários ocupados em um mês específico para um espaço.
+     * Obtém os horários ocupados em um mês específico, com filtro opcional por espaço
+     * ou equipamento.
      *
-     * @param mes      mês (1-12)
-     * @param ano      ano
-     * @param espacoId identificador do espaço
-     * @return horários ocupados agrupados por dia
+     * Apenas um filtro deve ser informado por chamada. Se ambos forem nulos, todas as
+     * reservas aprovadas do mês são retornadas.
+     *
+     * @param mes           mês (1-12)
+     * @param ano           ano
+     * @param espacoId      identificador do espaço (opcional)
+     * @param equipamentoId identificador do equipamento (opcional); tem precedência sobre {@code espacoId}
+     * @return horários ocupados agrupados por dia e séries recorrentes
      */
-    HorariosOcupadosPorMesDTO obterHorariosOcupadosPorMes(Integer mes, Integer ano, String espacoId);
+    HorariosOcupadosPorMesDTO obterHorariosOcupadosPorMes(
+            Integer mes, Integer ano, String espacoId, String equipamentoId);
 
     /**
      * Obtém informações completas sobre uma reserva recorrente.

--- a/src/main/java/br/uece/alunos/sisreserva/v1/service/impl/EquipamentoServiceImpl.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/service/impl/EquipamentoServiceImpl.java
@@ -5,10 +5,12 @@ import br.uece.alunos.sisreserva.v1.domain.equipamento.useCase.CriarEquipamento;
 import br.uece.alunos.sisreserva.v1.domain.equipamento.useCase.DeletarEquipamento;
 import br.uece.alunos.sisreserva.v1.domain.equipamento.useCase.ObterEquipamentos;
 import br.uece.alunos.sisreserva.v1.domain.equipamento.useCase.ObterEstatisticasEquipamentos;
+import br.uece.alunos.sisreserva.v1.domain.equipamento.useCase.ObterHorariosOcupadosEquipamento;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoAtualizarDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EquipamentoRetornoDTO;
 import br.uece.alunos.sisreserva.v1.dto.equipamento.EstatisticasGeralEquipamentoDTO;
+import br.uece.alunos.sisreserva.v1.dto.solicitacaoReserva.HorariosOcupadosPorMesDTO;
 import br.uece.alunos.sisreserva.v1.service.EquipamentoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +27,7 @@ public class EquipamentoServiceImpl implements EquipamentoService {
     private final DeletarEquipamento deletarEquipamento;
     private final ObterEquipamentos obterEquipamentos;
     private final ObterEstatisticasEquipamentos obterEstatisticasEquipamentos;
+    private final ObterHorariosOcupadosEquipamento obterHorariosOcupadosEquipamento;
     private final br.uece.alunos.sisreserva.v1.domain.equipamento.useCase.GerarPDFEstatisticasEquipamentos gerarPDFEstatisticasEquipamentos;
     private final br.uece.alunos.sisreserva.v1.domain.equipamento.useCase.ObterEquipamentosReservaveis obterEquipamentosReservaveis;
 
@@ -56,6 +59,13 @@ public class EquipamentoServiceImpl implements EquipamentoService {
     @Override
     public byte[] gerarPDFEstatisticas(Integer mesInicial, Integer anoInicial, Integer mesFinal, Integer anoFinal, List<String> equipamentoIds, String tipoEquipamentoId, Boolean multiusuario, String espacoId) throws java.io.IOException {
         return gerarPDFEstatisticasEquipamentos.gerarPDF(mesInicial, anoInicial, mesFinal, anoFinal, equipamentoIds, tipoEquipamentoId, multiusuario, espacoId);
+    }
+
+    @Override
+    public HorariosOcupadosPorMesDTO obterHorariosOcupadosPorEquipamento(
+            String equipamentoId, Integer mes, Integer ano) {
+        return obterHorariosOcupadosEquipamento.obterHorariosOcupadosPorEquipamento(
+                equipamentoId, mes, ano);
     }
 
     @Override

--- a/src/main/java/br/uece/alunos/sisreserva/v1/service/impl/SolicitacaoReservaServiceImpl.java
+++ b/src/main/java/br/uece/alunos/sisreserva/v1/service/impl/SolicitacaoReservaServiceImpl.java
@@ -66,8 +66,9 @@ public class SolicitacaoReservaServiceImpl implements SolicitacaoReservaService 
     }
 
     @Override
-    public HorariosOcupadosPorMesDTO obterHorariosOcupadosPorMes(Integer mes, Integer ano, String espacoId) {
-        return obterHorariosOcupados.obterHorariosOcupadosPorMes(mes, ano, espacoId);
+    public HorariosOcupadosPorMesDTO obterHorariosOcupadosPorMes(
+            Integer mes, Integer ano, String espacoId, String equipamentoId) {
+        return obterHorariosOcupados.obterHorariosOcupadosPorMes(mes, ano, espacoId, equipamentoId);
     }
 
     @Override


### PR DESCRIPTION
…a para equipamento

- Adiciona parâmetro opcional equipamentoId na rota GET /solicitacao-reserva/horarios-ocupados para filtrar reservas aprovadas de um equipamento específico
- Cria nova rota GET /equipamento/{id}/horarios-ocupados que retorna os horários ocupados de um equipamento no mês, separando reservas simples por dia e séries recorrentes
- Adiciona campos equipamentoId e equipamentoNome nos DTOs HorarioOcupadoDTO e SerieHorariosOcupadosDTO
- Adiciona queries JPQL no repositório para buscar reservas simples e séries recorrentes aprovadas por equipamento
- Cria use case ObterHorariosOcupadosEquipamento com suporte a recorrência e exceções por ocorrência
- Atualiza ObterHorariosOcupadosEspaco para compatibilidade com os novos campos dos DTOs